### PR TITLE
introduce a helper class for the simulator setup

### DIFF
--- a/sim/Dockerfile
+++ b/sim/Dockerfile
@@ -12,7 +12,9 @@ WORKDIR /ns-allinone-3.29/ns-3.29
 RUN ./waf configure --build-profile=optimized
 RUN ./waf build
 
-COPY sim.cc ./scratch
+RUN mkdir ./scratch/sim
+COPY quic-network-simulator-helper.h quic-network-simulator-helper.cc ./scratch/sim/  
+COPY sim.cc ./scratch/sim
 
 COPY run.sh .
 RUN chmod +x ./run.sh

--- a/sim/quic-network-simulator-helper.cc
+++ b/sim/quic-network-simulator-helper.cc
@@ -37,6 +37,19 @@ QuicNetworkSimulatorHelper::QuicNetworkSimulatorHelper() {
   installNetDevice(right_node_, "eth1", Mac48AddressValue("02:51:55:49:43:01"), Ipv4InterfaceAddress("10.100.0.2", "255.255.0.0"));
 }
 
+void QuicNetworkSimulatorHelper::Run(Time duration) {
+  Ipv4GlobalRoutingHelper::PopulateRoutingTables();
+  // write the routing table to file
+  Ptr<OutputStreamWrapper> routingStream = Create<OutputStreamWrapper>("dynamic-global-routing.routes", std::ios::out);
+  Ipv4RoutingHelper::PrintRoutingTableAllAt(Seconds(0.), routingStream);
+
+  NS_LOG_INFO("Run Emulation.");
+  Simulator::Stop(duration);
+  Simulator::Run();
+  Simulator::Destroy();
+  NS_LOG_INFO("Done.");
+}
+
 Ptr<Node> QuicNetworkSimulatorHelper::GetLeftNode() const {
   return left_node_;
 }

--- a/sim/quic-network-simulator-helper.cc
+++ b/sim/quic-network-simulator-helper.cc
@@ -1,0 +1,46 @@
+#include "ns3/core-module.h"
+#include "ns3/fd-net-device-module.h"
+#include "ns3/internet-module.h"
+#include "quic-network-simulator-helper.h"
+
+using namespace ns3;
+
+void installNetDevice(Ptr<Node> node, std::string deviceName, Mac48AddressValue macAddress, Ipv4InterfaceAddress ipv4Address) {
+  EmuFdNetDeviceHelper emu;
+  emu.SetDeviceName(deviceName);
+  NetDeviceContainer devices = emu.Install(node);
+  Ptr<NetDevice> device = devices.Get(0);
+  device->SetAttribute("Address", macAddress);
+
+  Ptr<Ipv4> ipv4 = node->GetObject<Ipv4>();
+  uint32_t interface = ipv4->AddInterface(device);
+  ipv4->AddAddress(interface, ipv4Address);
+  ipv4->SetMetric(interface, 1);
+  ipv4->SetUp(interface);
+}
+
+QuicNetworkSimulatorHelper::QuicNetworkSimulatorHelper() {
+  GlobalValue::Bind("SimulatorImplementationType", StringValue("ns3::RealtimeSimulatorImpl"));
+  GlobalValue::Bind("ChecksumEnabled", BooleanValue(true));
+
+  NodeContainer nodes;
+  nodes.Create(2);
+  InternetStackHelper internet;
+  internet.Install(nodes);
+
+  left_node_ = nodes.Get(0);
+  right_node_ = nodes.Get(1);
+
+  NS_LOG_INFO("Create eth0");
+  installNetDevice(left_node_, "eth0", Mac48AddressValue("02:51:55:49:43:00"), Ipv4InterfaceAddress("10.0.0.2", "255.255.0.0"));
+  NS_LOG_INFO("Create eth1");
+  installNetDevice(right_node_, "eth1", Mac48AddressValue("02:51:55:49:43:01"), Ipv4InterfaceAddress("10.100.0.2", "255.255.0.0"));
+}
+
+Ptr<Node> QuicNetworkSimulatorHelper::GetLeftNode() const {
+  return left_node_;
+}
+
+Ptr<Node> QuicNetworkSimulatorHelper::GetRightNode() const {
+  return right_node_;
+}

--- a/sim/quic-network-simulator-helper.h
+++ b/sim/quic-network-simulator-helper.h
@@ -8,6 +8,7 @@ using namespace ns3;
 class QuicNetworkSimulatorHelper {
 public:
   QuicNetworkSimulatorHelper();
+  void Run(Time);
   Ptr<Node> GetLeftNode() const;
   Ptr<Node> GetRightNode() const;
 

--- a/sim/quic-network-simulator-helper.h
+++ b/sim/quic-network-simulator-helper.h
@@ -1,0 +1,18 @@
+#ifndef QUIC_NETWORK_SIMULATOR_HELPER_H
+#define QUIC_NETWORK_SIMULATOR_HELPER_H
+
+#include "ns3/node.h"
+
+using namespace ns3;
+
+class QuicNetworkSimulatorHelper {
+public:
+  QuicNetworkSimulatorHelper();
+  Ptr<Node> GetLeftNode() const;
+  Ptr<Node> GetRightNode() const;
+
+private:
+  Ptr<Node> left_node_, right_node_;
+};
+
+#endif /* QUIC_NETWORK_SIMULATOR_HELPER_H */

--- a/sim/sim.cc
+++ b/sim/sim.cc
@@ -1,61 +1,29 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
 
-#include "ns3/abort.h"
 #include "ns3/core-module.h"
 #include "ns3/internet-module.h"
-#include "ns3/network-module.h"
-#include "ns3/fd-net-device-module.h"
-#include "ns3/internet-apps-module.h"
-#include "ns3/ipv4-static-routing-helper.h"
-#include "ns3/ipv4-list-routing-helper.h"
 #include "ns3/point-to-point-module.h"
-
+#include "quic-network-simulator-helper.h"
 
 using namespace ns3;
 
 NS_LOG_COMPONENT_DEFINE("ns3 simulator");
 
-void installNetDevice(Ptr<Node> node, std::string deviceName, Mac48AddressValue macAddress, Ipv4InterfaceAddress ipv4Address) {
-  EmuFdNetDeviceHelper emu;
-  emu.SetDeviceName(deviceName);
-  NetDeviceContainer devices = emu.Install(node);
-  Ptr<NetDevice> device = devices.Get(0);
-  device->SetAttribute("Address", macAddress);
-
-  Ptr<Ipv4> ipv4 = node->GetObject<Ipv4>();
-  uint32_t interface = ipv4->AddInterface(device);
-  ipv4->AddAddress(interface, ipv4Address);
-  ipv4->SetMetric(interface, 1);
-  ipv4->SetUp(interface);
-}
-
-
 int main(int argc, char *argv[]) {
-  GlobalValue::Bind("SimulatorImplementationType", StringValue("ns3::RealtimeSimulatorImpl"));
-  GlobalValue::Bind("ChecksumEnabled", BooleanValue(true));
-
-  NodeContainer nodes;
-  nodes.Create(2);
-  InternetStackHelper internet;
-  internet.Install(nodes);
+  QuicNetworkSimulatorHelper sim;
 
   // Stick in the point-to-point line between the sides.
   PointToPointHelper p2p;
   p2p.SetDeviceAttribute("DataRate", StringValue("10Mbps"));
   p2p.SetChannelAttribute("Delay", StringValue("10ms"));
 
-  NetDeviceContainer devices = p2p.Install(nodes);
+  NetDeviceContainer devices = p2p.Install(sim.GetLeftNode(), sim.GetRightNode());
 
   Ipv4AddressHelper ipv4;
   ipv4.SetBase("10.50.0.0", "255.255.0.0");
   Ipv4InterfaceContainer interfaces = ipv4.Assign(devices);
 
-  NS_LOG_INFO("Create eth0");
-  installNetDevice(nodes.Get(0), "eth0", Mac48AddressValue("02:51:55:49:43:00"), Ipv4InterfaceAddress("10.0.0.2", "255.255.0.0"));
-  NS_LOG_INFO("Create eth1");
-  installNetDevice(nodes.Get(1), "eth1", Mac48AddressValue("02:51:55:49:43:01"), Ipv4InterfaceAddress("10.100.0.2", "255.255.0.0"));
-
-  Ipv4GlobalRoutingHelper::PopulateRoutingTables ();
+  Ipv4GlobalRoutingHelper::PopulateRoutingTables();
 
   // write the routing table to file
   Ptr<OutputStreamWrapper> routingStream = Create<OutputStreamWrapper>("dynamic-global-routing.routes", std::ios::out);

--- a/sim/sim.cc
+++ b/sim/sim.cc
@@ -18,20 +18,9 @@ int main(int argc, char *argv[]) {
   p2p.SetChannelAttribute("Delay", StringValue("10ms"));
 
   NetDeviceContainer devices = p2p.Install(sim.GetLeftNode(), sim.GetRightNode());
-
   Ipv4AddressHelper ipv4;
   ipv4.SetBase("10.50.0.0", "255.255.0.0");
   Ipv4InterfaceContainer interfaces = ipv4.Assign(devices);
 
-  Ipv4GlobalRoutingHelper::PopulateRoutingTables();
-
-  // write the routing table to file
-  Ptr<OutputStreamWrapper> routingStream = Create<OutputStreamWrapper>("dynamic-global-routing.routes", std::ios::out);
-  Ipv4RoutingHelper::PrintRoutingTableAllAt(Seconds(0.), routingStream);
-
-  NS_LOG_INFO("Run Emulation.");
-  Simulator::Stop(Seconds(36000.0));
-  Simulator::Run();
-  Simulator::Destroy();
-  NS_LOG_INFO("Done.");
+  sim.Run(Seconds(36000));
 }


### PR DESCRIPTION
@janaiyengar Do you think this is the right way to move forward with this? Looking for feedback on how to establish a reasonable setup here, that will allow us to write scenarios with minimal boilerplate overhead, while preserving all the flexibility we can possible need.

With this proposal, a simulator script would look something like this:
```cpp
QuicNetworkSimulatorHelper sim;

PointToPointHelper p2p;
// set RTT, bandwidth, loss rate of the link
NetDeviceContainer devices = p2p.Install(sim.GetLeftNode(), sim.GetRightNode());

Ipv4AddressHelper ipv4;
ipv4.SetBase("10.50.0.0", "255.255.0.0");
Ipv4InterfaceContainer interfaces = ipv4.Assign(devices);

// Install apps on the nodes, or extend the network.
// Nodes are available via sim.GetLeftNode() and sim.GetRightNode().

// Sets up routing, exports routing table, and then starts the simulation.
sim.Run(Seconds(3600));
```