### PR TITLE
introduce a QuicPointToPointHelper

### DIFF
--- a/sim/scenarios/helper/quic-point-to-point-helper.cc
+++ b/sim/scenarios/helper/quic-point-to-point-helper.cc
@@ -1,0 +1,15 @@
+#include "ns3/core-module.h"
+#include "ns3/traffic-control-helper.h"
+#include "quic-point-to-point-helper.h"
+
+using namespace ns3;
+
+NetDeviceContainer QuicPointToPointHelper::Install(Ptr<Node> a, Ptr<Node> b) {
+  NetDeviceContainer devices = PointToPointHelper::Install(a, b);
+  
+  TrafficControlHelper tch;
+  tch.SetRootQueueDisc("ns3::PfifoFastQueueDisc", "MaxSize", StringValue("1p"));
+  tch.Install(devices);
+
+  return devices;
+}

--- a/sim/scenarios/helper/quic-point-to-point-helper.cc
+++ b/sim/scenarios/helper/quic-point-to-point-helper.cc
@@ -4,11 +4,19 @@
 
 using namespace ns3;
 
+QuicPointToPointHelper::QuicPointToPointHelper() : queue_size_(StringValue("100p")) {
+  SetQueue("ns3::DropTailQueue", "MaxSize", StringValue("1p"));
+}
+
+void QuicPointToPointHelper::SetQueueSize(StringValue size) {
+  queue_size_ = size;
+}
+
 NetDeviceContainer QuicPointToPointHelper::Install(Ptr<Node> a, Ptr<Node> b) {
   NetDeviceContainer devices = PointToPointHelper::Install(a, b);
   
   TrafficControlHelper tch;
-  tch.SetRootQueueDisc("ns3::PfifoFastQueueDisc", "MaxSize", StringValue("1p"));
+  tch.SetRootQueueDisc("ns3::PfifoFastQueueDisc", "MaxSize", queue_size_);
   tch.Install(devices);
 
   return devices;

--- a/sim/scenarios/helper/quic-point-to-point-helper.h
+++ b/sim/scenarios/helper/quic-point-to-point-helper.h
@@ -1,0 +1,17 @@
+#ifndef QUIC_POINT_TO_POINT_HELPER_H
+#define QUIC_POINT_TO_POINT_HELPER_H
+
+#include "ns3/point-to-point-module.h"
+
+using namespace ns3;
+
+// The QuicPointToPointHelper acts like the ns3::PointToPointHelper,
+// but it sets the PfifoFastQueueDisc queue size to 1, preventing the build-up
+// of traffic control layer queues and minimizing the impact on the latency.
+// Note that you can still set a network queue using PointToPointHelper::SetQueue.
+class QuicPointToPointHelper : public PointToPointHelper {
+public:
+  NetDeviceContainer Install(Ptr<Node> a, Ptr<Node> b);
+};
+
+#endif /* QUIC_POINT_TO_POINT_HELPER_H */

--- a/sim/scenarios/helper/quic-point-to-point-helper.h
+++ b/sim/scenarios/helper/quic-point-to-point-helper.h
@@ -6,12 +6,18 @@
 using namespace ns3;
 
 // The QuicPointToPointHelper acts like the ns3::PointToPointHelper,
-// but it sets the PfifoFastQueueDisc queue size to 1, preventing the build-up
-// of traffic control layer queues and minimizing the impact on the latency.
-// Note that you can still set a network queue using PointToPointHelper::SetQueue.
+// but sets a ns3::DropTailQueue to one packet in order to minimize queueing latency.
+// Queues are simulated using a PfifoFastQueueDisc, with a default size of 100 packets.
+// The queue size can be set to a custom value using SetQueueSize().
 class QuicPointToPointHelper : public PointToPointHelper {
 public:
+  QuicPointToPointHelper();
+
+  // SetQueueSize sets the queue size for the PfifoFastQueueDisc
+  void SetQueueSize(StringValue);
   NetDeviceContainer Install(Ptr<Node> a, Ptr<Node> b);
+private:
+  StringValue queue_size_; // for the PfifoFastQueueDisc
 };
 
 #endif /* QUIC_POINT_TO_POINT_HELPER_H */

--- a/sim/scenarios/simple-p2p/simple-p2p.cc
+++ b/sim/scenarios/simple-p2p/simple-p2p.cc
@@ -22,7 +22,7 @@ int main(int argc, char *argv[]) {
   QuicPointToPointHelper p2p;
   p2p.SetDeviceAttribute("DataRate", StringValue(bandwidth));
   p2p.SetChannelAttribute("Delay", StringValue(delay));
-  p2p.SetQueue("ns3::DropTailQueue", "MaxSize", StringValue(queue + "p"));
+  p2p.SetQueueSize(StringValue(queue + "p"));
 
   NetDeviceContainer devices = p2p.Install(sim.GetLeftNode(), sim.GetRightNode());
   Ipv4AddressHelper ipv4;

--- a/sim/scenarios/simple-p2p/simple-p2p.cc
+++ b/sim/scenarios/simple-p2p/simple-p2p.cc
@@ -2,6 +2,7 @@
 #include "ns3/internet-module.h"
 #include "ns3/point-to-point-module.h"
 #include "../helper/quic-network-simulator-helper.h"
+#include "../helper/quic-point-to-point-helper.h"
 
 using namespace ns3;
 
@@ -12,13 +13,13 @@ int main(int argc, char *argv[]) {
   CommandLine cmd;
   cmd.AddValue("delay", "delay of the p2p link", delay);
   cmd.AddValue("bandwidth", "bandwidth of the p2p link", bandwidth);
-  cmd.AddValue("queue", "queue size of the p2p link", queue);
+  cmd.AddValue("queue", "queue size of the p2p link (in packets)", queue);
   cmd.Parse (argc, argv);
 
   QuicNetworkSimulatorHelper sim;
 
   // Stick in the point-to-point line between the sides.
-  PointToPointHelper p2p;
+  QuicPointToPointHelper p2p;
   p2p.SetDeviceAttribute("DataRate", StringValue(bandwidth));
   p2p.SetChannelAttribute("Delay", StringValue(delay));
   p2p.SetQueue("ns3::DropTailQueue", "MaxSize", StringValue(queue + "p"));

--- a/sim/scenarios/udp-cross-traffic/udp-cross-traffic.cc
+++ b/sim/scenarios/udp-cross-traffic/udp-cross-traffic.cc
@@ -3,6 +3,7 @@
 #include "ns3/point-to-point-module.h"
 #include "ns3/applications-module.h"
 #include "../helper/quic-network-simulator-helper.h"
+#include "../helper/quic-point-to-point-helper.h"
 
 using namespace ns3;
 
@@ -13,13 +14,13 @@ int main(int argc, char *argv[]) {
   CommandLine cmd;
   cmd.AddValue("delay", "delay of the p2p link", delay);
   cmd.AddValue("bandwidth", "bandwidth of the p2p link", bandwidth);
-  cmd.AddValue("queue", "queue size of the p2p link", queue);
+  cmd.AddValue("queue", "queue size of the p2p link (in packets)", queue);
   cmd.AddValue("crossdatarate", "data rate of the cross traffic", cross_data_rate);
   cmd.Parse (argc, argv);
 
   QuicNetworkSimulatorHelper sim;
 
-  PointToPointHelper p2p;
+  QuicPointToPointHelper p2p;
   p2p.SetDeviceAttribute("DataRate", StringValue(bandwidth));
   p2p.SetChannelAttribute("Delay", StringValue(delay));
   p2p.SetQueue("ns3::DropTailQueue", "MaxSize", StringValue(queue + "p"));

--- a/sim/scenarios/udp-cross-traffic/udp-cross-traffic.cc
+++ b/sim/scenarios/udp-cross-traffic/udp-cross-traffic.cc
@@ -23,7 +23,7 @@ int main(int argc, char *argv[]) {
   QuicPointToPointHelper p2p;
   p2p.SetDeviceAttribute("DataRate", StringValue(bandwidth));
   p2p.SetChannelAttribute("Delay", StringValue(delay));
-  p2p.SetQueue("ns3::DropTailQueue", "MaxSize", StringValue(queue + "p"));
+  p2p.SetQueueSize(StringValue(queue + "p"));
 
   NetDeviceContainer devices = p2p.Install(sim.GetLeftNode(), sim.GetRightNode());
   Ipv4AddressHelper ipv4;

--- a/sim/wscript.patch
+++ b/sim/wscript.patch
@@ -1,6 +1,6 @@
 --- wscript.orig
 +++ wscript
-@@ -758,12 +758,13 @@
+@@ -758,12 +758,14 @@
  
      try:
          for filename in os.listdir("scratch"):
@@ -12,6 +12,7 @@
                  obj.path = obj.path.find_dir('scratch').find_dir(filename)
                  obj.source = obj.path.ant_glob('*.cc')
 +                obj.source.append('../helper/quic-network-simulator-helper.cc')
++                obj.source.append('../helper/quic-point-to-point-helper.cc')
                  obj.target = filename
                  obj.name = obj.target
                  obj.install_path = None


### PR DESCRIPTION
The `QuicPointToPointHelper` is a minimal wrapper around the `ns3::PointToPointHelper`, which always uses `PfifoFastQueueDisc` with a custom queue size. It uses the minimum possible device queue length.