### PR TITLE
Simplifies compose workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ on
 
 Follow these steps to set up your own QUIC implementation:
 
-1. Create a new directory for your implementation (say, my_impl_dir). You will
-   create four files in this directory: `Dockerfile`, `run_endpoint.sh`,
-   `server.yml`, and `client.yml` as described below.
+1. Create a new directory for your implementation (say, my_quic_impl). You will
+   create two files in this directory: `Dockerfile` and `run_endpoint.sh`, as
+   described below.
 
 1.  Copy the Dockerfile below and add the commands to build your QUIC
     implementation.
@@ -86,34 +86,17 @@ Follow these steps to set up your own QUIC implementation:
     fi
     ```
 
-1. Next, you need to create your custom YAML files that will be used by
-   docker-compose to bring up your server or client. Copy the following into
-   `server.yml` file.
-
-    ```yaml
-    version: "3.7"
-    services:
-        server:
-            image: my_quic_implementation
-    ```
-
-    And the following into a `client.yml` file:
-    ```yaml
-    version: "3.7"
-    services:
-        client:
-            image: my_quic_implementation
-    ```
-
-1. Finally, from the quic-network-simulator directory, build your image and assign a
-   tag. For example, "my_quic_implementation":
+1. Finally, from the quic-network-simulator directory, build your image and
+   assign it a tag. IMPORTANT: Use the same name for the tag as you did for your
+   directory, else docker-compose will fail. In our example, this would be
+   "my_quic_impl":
 
    ```
-   docker build my_impl_dir -t my_quic_implementation
+   docker build my_quic_impl/ -t my_quic_impl
    ```
 
    Note that you will need to run this build command any time you change your
-   implementation, the Dockerfile, or the `run_endpoint.sh` file.
+   implementation or either of the files described above.
 
 For an example, have a look at the [quic-go
 setup](https://github.com/marten-seemann/quic-go-docker) or the [quicly
@@ -131,26 +114,27 @@ provided are listed below:
 
 You can now run the experiment as follows:
 ```
+   CLIENT=[client directory name] \
    CLIENT_PARAMS=[params to client] \
+   SERVER=[server directory name] \
    SERVER_PARAMS=[params to server] \
    SCENARIO=[scenario] \
-   docker-compose -f base.yml \
-        -f [server_image]/server.yml \
-        -f [client_image]/client.yml \
-        up
+   docker-compose up
 ```
 
-For instance, the following command runs a simple point-to-point scenario, and
-specifies a command line parameter for the client implementation:
+SERVER_PARAMS and CLIENT_PARAMS may be omitted if the corresponding QUIC
+implementations do not require them.
+
+For instance, the following command runs a simple point-to-point scenario and
+specifies a command line parameter for only the client implementation:
+
 ```
+   CLIENT="my_quic_impl" \
    CLIENT_PARAMS="-p /10000.txt" \
+   SERVER="another_quic_impl" \
    SCENARIO="simple-p2p --delay=15ms --bandwidth=10Mbps --queue=25" \
-   docker-compose -f base.yml \
-        -f my_quic_implementation/server.yml \
-        -f another_quic_impl/client.yml \
-        up
+   docker-compose up
 ```
-
 
 A mounted directory, `qnslogs`, is provided for recording logs from the
 endpoints. This directory is created by docker-compose in the directory from

--- a/README.md
+++ b/README.md
@@ -86,18 +86,6 @@ Follow these steps to set up your own QUIC implementation:
     fi
     ```
 
-1. Finally, from the quic-network-simulator directory, build your image and
-   assign it a tag. IMPORTANT: Use the same name for the tag as you did for your
-   directory, else docker-compose will fail. In our example, this would be
-   "my_quic_impl":
-
-   ```
-   docker build my_quic_impl/ -t my_quic_impl
-   ```
-
-   Note that you will need to run this build command any time you change your
-   implementation or either of the files described above.
-
 For an example, have a look at the [quic-go
 setup](https://github.com/marten-seemann/quic-go-docker) or the [quicly
 setup](https://github.com/h2o/h2o-qns).
@@ -105,41 +93,60 @@ setup](https://github.com/h2o/h2o-qns).
 
 ## Running a Simulation
 
-You will want to run the setup with a scenario. The scenarios that are currently
-provided are listed below:
+1. From the quic-network-simulator directory, first build the necessary images:
+
+   ```
+   CLIENT=[client directory name] \
+   SERVER=[server directory name] \
+   docker-compose build
+   ```
+
+   Note that you will need to run this build command any time you change either
+   implementation, either `Dockerfile`, or either `run_endpoint.sh` file.
+
+   For instance:
+
+   ```
+   CLIENT="my_quic_impl" \
+   SERVER="another_quic_impl" \
+   docker-compose build
+   ```
+
+1. You will want to run the setup with a scenario. The scenarios that are
+   currently provided are listed below:
    
-* [Simple point-to-point link, with configurable link properties](sim/scenarios/simple-p2p)
+   * [Simple point-to-point link, with configurable link properties](sim/scenarios/simple-p2p)
 
-* [Single TCP connection running over a configurable point-to-point link](sim/scenarios/tcp-cross-traffic)
+   * [Single TCP connection running over a configurable point-to-point link](sim/scenarios/tcp-cross-traffic)
 
-You can now run the experiment as follows:
-```
+   You can now run the experiment as follows:
+   ```
    CLIENT=[client directory name] \
    CLIENT_PARAMS=[params to client] \
    SERVER=[server directory name] \
    SERVER_PARAMS=[params to server] \
    SCENARIO=[scenario] \
    docker-compose up
-```
+   ```
 
-SERVER_PARAMS and CLIENT_PARAMS may be omitted if the corresponding QUIC
-implementations do not require them.
+   SERVER_PARAMS and CLIENT_PARAMS may be omitted if the corresponding QUIC
+   implementations do not require them.
 
-For instance, the following command runs a simple point-to-point scenario and
-specifies a command line parameter for only the client implementation:
+   For instance, the following command runs a simple point-to-point scenario and
+   specifies a command line parameter for only the client implementation:
 
-```
+   ```
    CLIENT="my_quic_impl" \
    CLIENT_PARAMS="-p /10000.txt" \
    SERVER="another_quic_impl" \
    SCENARIO="simple-p2p --delay=15ms --bandwidth=10Mbps --queue=25" \
    docker-compose up
-```
+   ```
 
-A mounted directory, `qnslogs`, is provided for recording logs from the
-endpoints. This directory is created by docker-compose in the directory from
-which it is run. Inside the docker container, the directory is available as
-`/qnslogs`.
+   A mounted directory, `qnslogs`, is provided for recording logs from the
+   endpoints. This directory is created by docker-compose in the directory from
+   which it is run. Inside the docker container, the directory is available as
+   `/qnslogs`.
 
 
 ## Debugging and FAQs

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ setup](https://github.com/h2o/h2o-qns).
    docker-compose build
    ```
 
-   Note that you will need to run this build command any time you change either
-   implementation, either `Dockerfile`, or either `run_endpoint.sh` file.
+   Note that you will need to run this build command any time you change the
+   client or server implementation, `Dockerfile`, or `run_endpoint.sh` file.
 
    For instance:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,9 +17,11 @@ services:
         ipv4_address: 192.168.100.2
 
   server:
-    build: .
+    build: ./$SERVER
+    image: $SERVER
     container_name: server
     hostname: server
+    privileged: true
     volumes:
       - ./qnslogs:/qnslogs
     environment:
@@ -34,9 +36,11 @@ services:
         ipv4_address: 192.168.100.100
 
   client:
-    build: .
+    build: ./$CLIENT
+    image: $CLIENT
     container_name: client
     hostname: client
+    privileged: true
     volumes:
       - ./qnslogs:/qnslogs
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     image: sim
     container_name: sim
     hostname: sim
+    stdin_open: true
+    tty: true
     environment:
       - SCENARIO=$SCENARIO
     cap_add: 
@@ -22,6 +24,8 @@ services:
     container_name: server
     hostname: server
     privileged: true
+    stdin_open: true
+    tty: true
     volumes:
       - ./qnslogs:/qnslogs
     environment:
@@ -41,6 +45,8 @@ services:
     container_name: client
     hostname: client
     privileged: true
+    stdin_open: true
+    tty: true
     volumes:
       - ./qnslogs:/qnslogs
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,6 @@ services:
     image: $SERVER
     container_name: server
     hostname: server
-    privileged: true
     stdin_open: true
     tty: true
     volumes:
@@ -44,7 +43,6 @@ services:
     image: $CLIENT
     container_name: client
     hostname: client
-    privileged: true
     stdin_open: true
     tty: true
     volumes:

--- a/endpoint/client.yml
+++ b/endpoint/client.yml
@@ -1,6 +1,0 @@
-version: "3.7"
-services:
-  client:
-    image: endpoint
-    stdin_open: true
-    tty: true

--- a/endpoint/server.yml
+++ b/endpoint/server.yml
@@ -1,6 +1,0 @@
-version: "3.7"
-services:
-  server:
-    image: endpoint
-    stdin_open: true
-    tty: true


### PR DESCRIPTION
This PR removes the need for per-project yml files, making the client and server simple environment variables. It also replaces docker build with docker-compose build, streamlining and unifying the build and run mechanisms. To run an experiment, a user now does the following:
```
   CLIENT=[client directory name] \
   SERVER=[server directory name] \
   docker-compose build

   CLIENT=[client directory name] \
   CLIENT_PARAMS=[params to client] \
   SERVER=[server directory name] \
   SERVER_PARAMS=[params to server] \
   SCENARIO=[scenario] \
   docker-compose up	
```

The README is modified to contain appropriate instructions.