### PR TITLE
Fixes bug with using static int in droplist

### DIFF
--- a/sim/scenarios/droplist/droplist-error-model.cc
+++ b/sim/scenarios/droplist/droplist-error-model.cc
@@ -17,7 +17,6 @@ DroplistErrorModel::DroplistErrorModel() { }
 void DroplistErrorModel::DoReset(void) { }
  
 bool DroplistErrorModel::DoCorrupt(Ptr<Packet> p) {
-    static int packet_num = 0;
     if(drops.find(++packet_num) == drops.end())
         return false;
     cout << "Dropping packet number " << packet_num << endl;

--- a/sim/scenarios/droplist/droplist-error-model.cc
+++ b/sim/scenarios/droplist/droplist-error-model.cc
@@ -12,7 +12,8 @@ TypeId DroplistErrorModel::GetTypeId(void) {
     return tid;
 }
  
-DroplistErrorModel::DroplistErrorModel() { }
+DroplistErrorModel::DroplistErrorModel()
+    : packet_num(0) { }
 
 void DroplistErrorModel::DoReset(void) { }
  

--- a/sim/scenarios/droplist/droplist-error-model.h
+++ b/sim/scenarios/droplist/droplist-error-model.h
@@ -18,6 +18,7 @@ class DroplistErrorModel : public ErrorModel {
     
  private:
     std::set<int> drops;
+    int packet_num;
     bool DoCorrupt (Ptr<Packet> p);
     void DoReset(void);
 };


### PR DESCRIPTION
The code used packet_num as a static int, which made it a shared variable across instances of DropListErrorModel, meaning that packet counts were global, and not just in one direction. This PR fixes it.