### PR TITLE
fix endpoint build directory

### DIFF
--- a/base.yml
+++ b/base.yml
@@ -17,7 +17,7 @@ services:
         ipv4_address: 192.168.100.2
 
   server:
-    build: .
+    build: endpoint
     container_name: server
     hostname: server
     volumes:
@@ -34,7 +34,7 @@ services:
         ipv4_address: 192.168.100.100
 
   client:
-    build: .
+    build: endpoint
     container_name: client
     hostname: client
     volumes:


### PR DESCRIPTION
Now you can run the whole `docker-compose ... up` command with the `--build` flag (which will rebuild every container, if necessary).