### PR TITLE
add command line flags to select servers and clients for interop

### DIFF
--- a/interop/run.py
+++ b/interop/run.py
@@ -120,10 +120,10 @@ class InteropRunner:
     t = prettytable.PrettyTable()
     t.hrules = prettytable.ALL
     t.vrules = prettytable.ALL
-    t.field_names = [ "" ] + [ name for name in self._clients ]
-    for server in self._servers:
-      row = [ server ]
-      for client in self._clients:
+    t.field_names = [ "" ] + [ name for name in self._servers ]
+    for client in self._clients:
+      row = [ client ]
+      for server in self._servers:
         cell = self.results[server][client]
         res = colored(get_letters(cell[TestResult.SUCCEEDED]), "green") + "\n"
         res += colored(get_letters(cell[TestResult.UNSUPPORTED]), "yellow") + "\n"


### PR DESCRIPTION
This PR adds two new flags: `--server` and `--client`. Both take a comma-separated list of implementation names that will be used for interop tests. If the flag is absent, all available implementations are used.
For example, if you want to test a quic-go server with both both quic-go and quicly as a client, you would use `--server=quicgo --client=quicgo,quicly`.