### PR TITLE
use docker-compose version 3.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: "3.5"
 
 services:
   sim:

--- a/interop/interop.yml
+++ b/interop/interop.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: "3.5"
 
 services:
   sim:


### PR DESCRIPTION
Apparently Debian ships with an old docker-compose version that doesn't work with version 3.7 yet.