### PR TITLE
Add ngtcp2 to interop implementations

### DIFF
--- a/interop/implementations.py
+++ b/interop/implementations.py
@@ -1,5 +1,6 @@
 # add your QUIC implementation here
 IMPLEMENTATIONS = { # name => docker image
   "quicgo": "martenseemann/quic-go-interop:latest",
-  "quicly": "janaiyengar/quicly:interop"
+  "quicly": "janaiyengar/quicly:interop",
+  "ngtcp2": "ngtcp2/ngtcp2-interop:latest"
 }


### PR DESCRIPTION
Add ngtcp2 to interop implementations.
Note that ngtcp2 client and server only speak HTTP/3.  No HTTP/0.9 support.