### PR TITLE
don't add additional entries to /etc/hosts in the setup script

### DIFF
--- a/endpoint/setup.sh
+++ b/endpoint/setup.sh
@@ -10,9 +10,6 @@ IP=`hostname -I`
 GATEWAY="${IP%.*}.2"
 UNNEEDED_ROUTE="${IP%.*}.0"
 
-echo "193.167.0.100 client" >> /etc/hosts
-echo "193.167.100.100 server" >> /etc/hosts
-
 route add -net 193.167.0.0 netmask 255.255.0.0 gw $GATEWAY
 # delete unused route
 route del -net $UNNEEDED_ROUTE netmask 255.255.255.0


### PR DESCRIPTION
As @larseggert pointed out, we don't need to add entries to `/etc/hosts` in the setup script. `docker-compose` will do it for us, and we can even configure it to add more entries using [extra_hosts](https://docs.docker.com/compose/compose-file/#extra_hosts).