### PR TITLE
make it possible to use a debug build of ns3

### DIFF
--- a/sim/Dockerfile
+++ b/sim/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && \
   apt-get clean
 
 WORKDIR /ns3
-COPY --from=builder /ns-allinone-3.30.1/ns-3.30.1/out/src/fd-net-device/*optimized /ns3/src/fd-net-device/
+COPY --from=builder /ns-allinone-3.30.1/ns-3.30.1/out/src/fd-net-device/*optimized /ns-allinone-3.30.1/ns-3.30.1/out/src/fd-net-device/*debug /ns3/src/fd-net-device/
 COPY --from=builder /ns-allinone-3.30.1/ns-3.30.1/out/scratch/*/* /ns3/scratch/
 COPY --from=builder /ns-allinone-3.30.1/ns-3.30.1/out/lib/ /ns3/lib
 

--- a/sim/scenarios/helper/quic-network-simulator-helper.cc
+++ b/sim/scenarios/helper/quic-network-simulator-helper.cc
@@ -39,9 +39,7 @@ QuicNetworkSimulatorHelper::QuicNetworkSimulatorHelper() {
   left_node_ = nodes.Get(0);
   right_node_ = nodes.Get(1);
 
-  NS_LOG_INFO("Create eth0");
   installNetDevice(left_node_, "eth0", Mac48AddressValue("02:51:55:49:43:00"), Ipv4InterfaceAddress("193.167.0.2", "255.255.255.0"));
-  NS_LOG_INFO("Create eth1");
   installNetDevice(right_node_, "eth1", Mac48AddressValue("02:51:55:49:43:01"), Ipv4InterfaceAddress("193.167.100.2", "255.255.255.0"));
 }
 
@@ -51,17 +49,15 @@ void QuicNetworkSimulatorHelper::Run(Time duration) {
   Ptr<OutputStreamWrapper> routingStream = Create<OutputStreamWrapper>("dynamic-global-routing.routes", std::ios::out);
   Ipv4RoutingHelper::PrintRoutingTableAllAt(Seconds(0.), routingStream);
 
-  NS_LOG_INFO("Run Emulation.");
   Simulator::Stop(duration);
   RunSynchronizer();
   Simulator::Run();
   Simulator::Destroy();
-  NS_LOG_INFO("Done.");
 }
 
 void QuicNetworkSimulatorHelper::RunSynchronizer() const {
   int sockfd = socket(AF_INET, SOCK_STREAM, 0);
-  if(sockfd < 0) NS_LOG_ERROR("ERROR opening socket");
+  NS_ABORT_MSG_IF(sockfd < 0, "ERROR opening socket");
 
   struct sockaddr_in addr;
   bzero((char *) &addr, sizeof(addr));
@@ -70,7 +66,8 @@ void QuicNetworkSimulatorHelper::RunSynchronizer() const {
   addr.sin_addr.s_addr = INADDR_ANY;  
   addr.sin_port = htons(57832);
 
-  if(bind(sockfd, (struct sockaddr *) &addr, sizeof(addr)) < 0) NS_LOG_ERROR("ERROR on binding");
+  int res = bind(sockfd, (struct sockaddr *) &addr, sizeof(addr));
+  NS_ABORT_MSG_IF(res < 0, "ERROR on binding");
   // We never intend to accept any of the connections.
   // Use a large backlog queue instead.
   listen(sockfd, 100);


### PR DESCRIPTION
For some reason, the log statements were causing compile time errors in when using a debug build.