### PR TITLE
set /etc/hosts entries for client and server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
     networks:
       rightnet:
         ipv4_address: 193.167.100.100
+    extra_hosts:
+      - "client:193.167.0.100"
 
   client:
     build: ./$CLIENT
@@ -60,6 +62,8 @@ services:
     networks:
       leftnet:
         ipv4_address: 193.167.0.100
+    extra_hosts:
+      - "server:193.167.100.100"
 
 networks:
   leftnet:


### PR DESCRIPTION
Set /etc/hosts entries via `docker-compose.yml`, since #56 removed this from the setup script.