### PR TITLE
add a scenario that corrupts packets

### DIFF
--- a/sim/scenarios/corrupt-rate/README.md
+++ b/sim/scenarios/corrupt-rate/README.md
@@ -17,8 +17,8 @@ This scenario has the following configurable properties:
 * `--queue`: Queue size of the queue attached to the link. Specified in
   packets. This is a required parameter. For example `--queue=25`.
 
-* `--rate_to_client`: A value between 0 and 100 specifying the packet drop rate
-  (in percentage) in the server to client direction. This is a required
+* `--rate_to_client`: A value between 0 and 100 specifying the packet corruption
+  rate (in percentage) in the server to client direction. This is a required
   parameter. For example, `--rate_to_client=10`.
 
 * `--rate_to_server`: Same as `rate_to_client` but in the other direction.

--- a/sim/scenarios/corrupt-rate/README.md
+++ b/sim/scenarios/corrupt-rate/README.md
@@ -1,0 +1,29 @@
+# Corrupt Rate
+
+This scenario uses a bottleneck link similar to the [simple-p2p](../simple-p2p)
+scenario and optionally allows configuring the link to corrupt packets in either
+direction. Packets to be corrupted are chosen randomly in both directions, based
+on rates specified by the user.
+
+This scenario has the following configurable properties:
+
+* `--delay`: One-way delay of network. Specify with units. This is a required
+  parameter. For example `--delay=15ms`.
+
+* `--bandwidth`: Bandwidth of the link. Specify with units. This is a required
+  parameter. For example `--bandwidth=10Mbps`. Specifying a value larger than
+  10Mbps may cause the simulator to saturate the CPU.
+
+* `--queue`: Queue size of the queue attached to the link. Specified in
+  packets. This is a required parameter. For example `--queue=25`.
+
+* `--rate_to_client`: A value between 0 and 100 specifying the packet drop rate
+  (in percentage) in the server to client direction. This is a required
+  parameter. For example, `--rate_to_client=10`.
+
+* `--rate_to_server`: Same as `rate_to_client` but in the other direction.
+
+For example,
+```bash
+./run.sh "corrupt-rate --delay=15ms --bandwidth=10Mbps --queue=25 --rate_to_client=10 --rate_to_server=20"
+```

--- a/sim/scenarios/corrupt-rate/corrupt-rate-error-model.cc
+++ b/sim/scenarios/corrupt-rate/corrupt-rate-error-model.cc
@@ -32,7 +32,7 @@ bool CorruptRateErrorModel::DoCorrupt(Ptr<Packet> p) {
 
     const uint32_t p_len = p->GetSize();
     uint8_t *buffer= new uint8_t[p_len];
-    p->CopyData(buffer, p->GetSize());
+    p->CopyData(buffer, p_len);
     PppHeader ppp_hdr = PppHeader();
     uint32_t ppp_hdr_len = p->RemoveHeader(ppp_hdr);
     Ipv4Header ip_hdr = Ipv4Header();
@@ -40,18 +40,26 @@ bool CorruptRateErrorModel::DoCorrupt(Ptr<Packet> p) {
     UdpHeader udp_hdr = UdpHeader();
     uint32_t udp_hdr_len = p->RemoveHeader(udp_hdr);
     const uint32_t hdr_len = ppp_hdr_len + ip_hdr_len + udp_hdr_len;
-    std::uniform_int_distribution<> d(hdr_len, hdr_len + p->GetSize() - 1);
+    // Corrupt a byte in the 50 bytes of the UDP payload.
+    // This way, we will frequenetly hit the QUIC header.
+    std::uniform_int_distribution<> d(hdr_len, hdr_len + min(uint32_t(50), p->GetSize() - 1));
     auto pos = d(*rng);
     buffer[pos] ^= 0xff;
     cout << "Corrupting byte " << pos - hdr_len << " of the UDP payload (total: " << p->GetSize() << ")" << endl;
-    uint32_t payload_len = p_len - hdr_len;
-    Packet new_p = Packet(&buffer[hdr_len], payload_len);
-    udp_hdr.ForcePayloadSize(payload_len + udp_hdr_len);
+
+    // Re-assemble a new packet.
+    uint32_t udp_payload_len = p_len - hdr_len;
+    // Start with the UDP payload (including the corrupted bytes).
+    Packet new_p = Packet(&buffer[hdr_len], udp_payload_len);
+    // Add the UDP header and make sure to recalculate the checksum.
+    udp_hdr.ForcePayloadSize(udp_payload_len + udp_hdr_len);
     udp_hdr.ForceChecksum(0);
     udp_hdr.InitializeChecksum(ip_hdr.GetSource(), ip_hdr.GetDestination(), ip_hdr.GetProtocol());
     new_p.AddHeader(udp_hdr);
+    // Add the IP header, again make sure to recalculate the checksum.
     ip_hdr.EnableChecksum();
     new_p.AddHeader(ip_hdr);
+    // Add the PPP header.
     new_p.AddHeader(ppp_hdr);
     p->RemoveAtEnd(p_len);
     p->AddAtEnd(Ptr<Packet>(&new_p));

--- a/sim/scenarios/corrupt-rate/corrupt-rate-error-model.cc
+++ b/sim/scenarios/corrupt-rate/corrupt-rate-error-model.cc
@@ -1,0 +1,63 @@
+#include <cstdint>
+
+#include "corrupt-rate-error-model.h"
+#include "ns3/header.h"
+#include "ns3/packet.h"
+#include "ns3/ppp-header.h"
+#include "ns3/ipv4-header.h"
+#include "ns3/udp-header.h"
+
+using namespace std;
+
+NS_OBJECT_ENSURE_REGISTERED(CorruptRateErrorModel);
+
+TypeId CorruptRateErrorModel::GetTypeId(void) {
+    static TypeId tid = TypeId("CorruptRateErrorModel")
+        .SetParent<ErrorModel>()
+        .AddConstructor<CorruptRateErrorModel>()
+        ;
+    return tid;
+}
+ 
+CorruptRateErrorModel::CorruptRateErrorModel()
+    : rate(0), distr(0, 99) {
+    std::random_device rd;
+    rng = new std::mt19937(rd());
+}
+
+void CorruptRateErrorModel::DoReset(void) { }
+
+bool CorruptRateErrorModel::DoCorrupt(Ptr<Packet> p) {
+    if (distr(*rng) >= rate) return false;
+
+    const uint32_t p_len = p->GetSize();
+    uint8_t *buffer= new uint8_t[p_len];
+    p->CopyData(buffer, p->GetSize());
+    PppHeader ppp_hdr = PppHeader();
+    uint32_t ppp_hdr_len = p->RemoveHeader(ppp_hdr);
+    Ipv4Header ip_hdr = Ipv4Header();
+    uint32_t ip_hdr_len = p->RemoveHeader(ip_hdr);
+    UdpHeader udp_hdr = UdpHeader();
+    uint32_t udp_hdr_len = p->RemoveHeader(udp_hdr);
+    const uint32_t hdr_len = ppp_hdr_len + ip_hdr_len + udp_hdr_len;
+    std::uniform_int_distribution<> d(hdr_len, hdr_len + p->GetSize() - 1);
+    auto pos = d(*rng);
+    buffer[pos] ^= 0xff;
+    cout << "Corrupting byte " << pos - hdr_len << " of the UDP payload (total: " << p->GetSize() << ")" << endl;
+    uint32_t payload_len = p_len - hdr_len;
+    Packet new_p = Packet(&buffer[hdr_len], payload_len);
+    udp_hdr.ForcePayloadSize(payload_len + udp_hdr_len);
+    udp_hdr.ForceChecksum(0);
+    udp_hdr.InitializeChecksum(ip_hdr.GetSource(), ip_hdr.GetDestination(), ip_hdr.GetProtocol());
+    new_p.AddHeader(udp_hdr);
+    ip_hdr.EnableChecksum();
+    new_p.AddHeader(ip_hdr);
+    new_p.AddHeader(ppp_hdr);
+    p->RemoveAtEnd(p_len);
+    p->AddAtEnd(Ptr<Packet>(&new_p));
+    return false;
+}
+
+void CorruptRateErrorModel::SetCorruptRate(int rate_in) {
+    rate = rate_in;
+}

--- a/sim/scenarios/corrupt-rate/corrupt-rate-error-model.h
+++ b/sim/scenarios/corrupt-rate/corrupt-rate-error-model.h
@@ -1,0 +1,26 @@
+#ifndef CORRUPTRATE_ERROR_MODEL_H
+#define CORRUPTRATE_ERROR_MODEL_H
+
+#include <set>
+#include <random>
+#include "ns3/error-model.h"
+
+using namespace ns3;
+
+// The CorruptRateErrorModel drops random packets, at a user-specified drop rate. 
+class CorruptRateErrorModel : public RateErrorModel {
+ public:
+    static TypeId GetTypeId(void);
+    CorruptRateErrorModel();
+    void SetCorruptRate(int perc);
+    
+ private:
+    int rate;
+    std::mt19937 *rng;
+    std::uniform_int_distribution<> distr;
+
+    bool DoCorrupt (Ptr<Packet> p);
+    void DoReset(void);
+};
+
+#endif /* CORRUPTRATE_ERROR_MODEL_H */

--- a/sim/scenarios/corrupt-rate/corrupt-rate.cc
+++ b/sim/scenarios/corrupt-rate/corrupt-rate.cc
@@ -1,0 +1,56 @@
+#include "ns3/core-module.h"
+#include "ns3/error-model.h"
+#include "ns3/internet-module.h"
+#include "ns3/point-to-point-module.h"
+#include "../helper/quic-network-simulator-helper.h"
+#include "../helper/quic-point-to-point-helper.h"
+#include "corrupt-rate-error-model.h"
+
+using namespace ns3;
+using namespace std;
+
+NS_LOG_COMPONENT_DEFINE("ns3 simulator");
+
+int main(int argc, char *argv[]) {
+    std::string delay, bandwidth, queue, client_rate, server_rate;
+    std::random_device rand_dev;
+    std::mt19937 generator(rand_dev());  // Seed random number generator first
+    Ptr<CorruptRateErrorModel> client_drops = CreateObject<CorruptRateErrorModel>();
+    Ptr<CorruptRateErrorModel> server_drops = CreateObject<CorruptRateErrorModel>();
+    CommandLine cmd;
+    
+    cmd.AddValue("delay", "delay of the p2p link", delay);
+    cmd.AddValue("bandwidth", "bandwidth of the p2p link", bandwidth);
+    cmd.AddValue("queue", "queue size of the p2p link (in packets)", queue);
+    cmd.AddValue("rate_to_client", "packet drop rate (towards client)", client_rate);
+    cmd.AddValue("rate_to_server", "packet drop rate (towards server)", server_rate);
+    cmd.Parse (argc, argv);
+    
+    NS_ABORT_MSG_IF(delay.length() == 0, "Missing parameter: delay");
+    NS_ABORT_MSG_IF(bandwidth.length() == 0, "Missing parameter: bandwidth");
+    NS_ABORT_MSG_IF(queue.length() == 0, "Missing parameter: queue");
+    NS_ABORT_MSG_IF(client_rate.length() == 0, "Missing parameter: rate_to_client");
+    NS_ABORT_MSG_IF(server_rate.length() == 0, "Missing parameter: rate_to_server");
+
+    // Set client and server drop rates.
+    client_drops->SetCorruptRate(stoi(client_rate));
+    server_drops->SetCorruptRate(stoi(server_rate));
+
+    QuicNetworkSimulatorHelper sim;
+
+    // Stick in the point-to-point line between the sides.
+    QuicPointToPointHelper p2p;
+    p2p.SetDeviceAttribute("DataRate", StringValue(bandwidth));
+    p2p.SetChannelAttribute("Delay", StringValue(delay));
+    p2p.SetQueueSize(StringValue(queue + "p"));
+    
+    NetDeviceContainer devices = p2p.Install(sim.GetLeftNode(), sim.GetRightNode());
+    Ipv4AddressHelper ipv4;
+    ipv4.SetBase("193.167.50.0", "255.255.255.0");
+    Ipv4InterfaceContainer interfaces = ipv4.Assign(devices);
+    
+    devices.Get(0)->SetAttribute("ReceiveErrorModel", PointerValue(client_drops));
+    devices.Get(1)->SetAttribute("ReceiveErrorModel", PointerValue(server_drops));
+    
+    sim.Run(Seconds(36000));
+}


### PR DESCRIPTION
A packet is corrupted by flipping all bits of a single byte. The corrupted byte is guaranteed to be part of the UDP payload. After corrupting the packet, UDP and IP checksums are re-calculated, to make sure the packet is actually delivered.