### PR TITLE
log forwarded packets in the CorruptRateErrorModel

### DIFF
--- a/sim/scenarios/corrupt-rate/corrupt-rate-error-model.cc
+++ b/sim/scenarios/corrupt-rate/corrupt-rate-error-model.cc
@@ -30,9 +30,14 @@ CorruptRateErrorModel::CorruptRateErrorModel()
 void CorruptRateErrorModel::DoReset(void) { }
 
 bool CorruptRateErrorModel::DoCorrupt(Ptr<Packet> p) {
-    if (distr(*rng) >= rate) return false;
-
     QuicPacket qp = QuicPacket(p);
+
+    if(distr(*rng) >= rate) {
+        cout << "Forwarding packet (size: " << qp.GetUdpPayload().size() << ")" << endl;
+        qp.ReassemblePacket();
+        return false;
+    }
+
     // Don't corrupt Version Negotiation packets.
     // Version Negotiation packets are expected to be sent when the version field of the Initial was corrupted.
     // Client are supposed to ignore Version Negotiation packets that contain the version that they offered.


### PR DESCRIPTION
I wish C++ had a `defer` statement like Go...