### PR TITLE
use Ubuntu 19.10 as base for the endpoint image

### DIFF
--- a/endpoint/Dockerfile
+++ b/endpoint/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.04
+FROM ubuntu:19.10
 
 RUN apt-get update && \
   apt-get install -y wget net-tools iputils-ping tcpdump ethtool iperf


### PR DESCRIPTION
Fixes #73.

cc @agrover