### PR TITLE
More info for packet disposition for drop/corrupt scenarios

### DIFF
--- a/sim/scenarios/corrupt-rate/corrupt-rate-error-model.cc
+++ b/sim/scenarios/corrupt-rate/corrupt-rate-error-model.cc
@@ -54,11 +54,10 @@ bool CorruptRateErrorModel::DoCorrupt(Ptr<Packet> p) {
     while(true) {
         uint8_t n = std::uniform_int_distribution<>(0, 255)(*rng);
         if(payload[pos] == n) continue;
-        printf("Corrupting byte %d (%#x -> %#x) of the UDP payload (total: %d)\n", pos, payload[pos], n, (int) payload.size());
+        cout << "Corrupted packet (" << qp.GetUdpPayload().size() << " bytes) from" << qp.GetIpv4Header().GetSource() << " at offset " << pos << " (0x" << std::hex << payload[pos] << " -> 0x" << n << ")";
         payload[pos] = n;
         break;
     }
-    cout << "Corrupted packet (" << qp.GetUdpPayload().size() << " bytes) from " << qp.GetIpv4Header().GetSource() << endl;
     qp.ReassemblePacket();
     return false;
 }

--- a/sim/scenarios/corrupt-rate/corrupt-rate-error-model.cc
+++ b/sim/scenarios/corrupt-rate/corrupt-rate-error-model.cc
@@ -33,7 +33,7 @@ bool CorruptRateErrorModel::DoCorrupt(Ptr<Packet> p) {
     QuicPacket qp = QuicPacket(p);
 
     if(distr(*rng) >= rate) {
-        cout << "Forwarding packet (size: " << qp.GetUdpPayload().size() << ")" << endl;
+        cout << "Forwarding packet (" << qp.GetUdpPayload().size() << " bytes) from " << qp.GetIpv4Header().GetSource() << endl;
         qp.ReassemblePacket();
         return false;
     }
@@ -58,6 +58,7 @@ bool CorruptRateErrorModel::DoCorrupt(Ptr<Packet> p) {
         payload[pos] = n;
         break;
     }
+    cout << "Corrupted packet (" << qp.GetUdpPayload().size() << " bytes) from " << qp.GetIpv4Header().GetSource() << endl;
     qp.ReassemblePacket();
     return false;
 }

--- a/sim/scenarios/drop-rate/drop-rate-error-model.cc
+++ b/sim/scenarios/drop-rate/drop-rate-error-model.cc
@@ -25,7 +25,7 @@ bool DropRateErrorModel::DoCorrupt(Ptr<Packet> p) {
     QuicPacket qp = QuicPacket(p);
 
     if (distr(*rng) >= rate) {
-        cout << "Forwarding packet (size: " << qp.GetUdpPayload().size() << ")" << endl;
+        cout << "Forwarding packet (" << qp.GetUdpPayload().size() << " bytes) from " << qp.GetIpv4Header().GetSource() << endl;
         qp.ReassemblePacket();
         return false;
     }


### PR DESCRIPTION
Drop: Add source IP to the "Forwarding packet" message, just like the
"dropping packet" message has.

Corrupt: Same as above, and also add a similar message when the packet is
corrupted and then forwarded.