### PR TITLE
Fix cout issues with corrupted packet log

### DIFF
--- a/sim/scenarios/corrupt-rate/corrupt-rate-error-model.cc
+++ b/sim/scenarios/corrupt-rate/corrupt-rate-error-model.cc
@@ -54,7 +54,7 @@ bool CorruptRateErrorModel::DoCorrupt(Ptr<Packet> p) {
     while(true) {
         uint8_t n = std::uniform_int_distribution<>(0, 255)(*rng);
         if(payload[pos] == n) continue;
-        cout << "Corrupted packet (" << qp.GetUdpPayload().size() << " bytes) from" << qp.GetIpv4Header().GetSource() << " at offset " << pos << " (0x" << std::hex << payload[pos] << " -> 0x" << n << ")";
+        cout << "Corrupted packet (" << qp.GetUdpPayload().size() << " bytes) from " << qp.GetIpv4Header().GetSource() << " at offset " << pos << " (0x" << std::hex << (unsigned int) payload[pos] << " -> 0x" << (unsigned int) n << ")" << std::dec << endl;
         payload[pos] = n;
         break;
     }


### PR DESCRIPTION
* add endl
* add missing space before printing ip address
* cast values to unsigned int so that hex printing works
* go back to decimal mode once hex printing is complete