### PR TITLE
add a wait-for-it script to check if a QUIC server is up

### DIFF
--- a/sim/Dockerfile
+++ b/sim/Dockerfile
@@ -26,6 +26,17 @@ RUN ./waf build  && \
   cd out/lib && du -sh . && strip -v * && du -sh . && cd ../.. && \
   cd out/scratch && rm -r subdir helper scratch-simulator*
 
+RUN cd / && \
+  wget https://dl.google.com/go/go1.15.linux-amd64.tar.gz && \
+  tar xfz go1.15.linux-amd64.tar.gz && \
+  rm go1.15.linux-amd64.tar.gz
+
+RUN ls -al /go
+
+ENV PATH="/go/bin:${PATH}"
+COPY wait-for-it-quic /wait-for-it-quic
+RUN cd /wait-for-it-quic && go build .
+
 FROM ubuntu:20.04
 
 RUN apt-get update && \
@@ -36,6 +47,7 @@ WORKDIR /ns3
 COPY --from=builder /ns3/out/src/fd-net-device/*optimized /ns3/out/src/fd-net-device/*debug /ns3/src/fd-net-device/
 COPY --from=builder /ns3/out/scratch/*/* /ns3/scratch/
 COPY --from=builder /ns3/out/lib/ /ns3/lib
+COPY --from=builder /wait-for-it-quic/wait-for-it-quic /usr/bin
 
 # see https://gitlab.com/nsnam/ns-3-dev/issues/97
 ENV PATH="/ns3/src/fd-net-device/:${PATH}"

--- a/sim/run.sh
+++ b/sim/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # We are using eth0 and eth1 as EmuFdNetDevices in ns3.
 # ns3 usually uses MAC address spoofing to separate ns3 from other traffic,
 # see https://www.nsnam.org/docs/models/html/fd-net-device.html#emufdnetdevicehelper.
@@ -17,6 +19,10 @@ ifconfig eth1 promisc
 # Drop those to make sure they actually take the path through ns3.
 iptables -A FORWARD -i eth0 -o eth1 -j DROP
 iptables -A FORWARD -i eth1 -o eth0 -j DROP
+
+if [[ -n "$WAITFORSERVER" ]]; then
+  wait-for-it-quic -t 10s $WAITFORSERVER
+fi
 
 echo "Using scenario:" $SCENARIO
 

--- a/sim/wait-for-it-quic/go.mod
+++ b/sim/wait-for-it-quic/go.mod
@@ -1,0 +1,3 @@
+module github.com/marten-seemann/quic-network-simulator/sim/wait-for-it-quic
+
+go 1.15


### PR DESCRIPTION
Wait until the server is actually up and running before booting up the simulator.

We do that by sending a packet with the QUIC version WAIT (in ASCII) to the server, which will elicit a Version Negotiation packet. Once we receive a VN packet, we know that the server is up.

When running the simulator, this is triggered by the environment variable `WAITFORSERVER` (which contains the address:port of the server to wait for). 