### PR TITLE
only apply error models to UDP packets

### DIFF
--- a/sim/scenarios/corrupt-rate/corrupt-rate-error-model.cc
+++ b/sim/scenarios/corrupt-rate/corrupt-rate-error-model.cc
@@ -30,6 +30,8 @@ CorruptRateErrorModel::CorruptRateErrorModel()
 void CorruptRateErrorModel::DoReset(void) { }
 
 bool CorruptRateErrorModel::DoCorrupt(Ptr<Packet> p) {
+    if(!IsUDPPacket(p)) return false;
+
     QuicPacket qp = QuicPacket(p);
 
     if(distr(*rng) >= rate) {

--- a/sim/scenarios/drop-rate/drop-rate-error-model.cc
+++ b/sim/scenarios/drop-rate/drop-rate-error-model.cc
@@ -22,6 +22,8 @@ DropRateErrorModel::DropRateErrorModel()
 void DropRateErrorModel::DoReset(void) { }
  
 bool DropRateErrorModel::DoCorrupt(Ptr<Packet> p) {
+    if(!IsUDPPacket(p)) return false;
+
     QuicPacket qp = QuicPacket(p);
 
     if (distr(*rng) >= rate) {

--- a/sim/scenarios/droplist/droplist-error-model.cc
+++ b/sim/scenarios/droplist/droplist-error-model.cc
@@ -1,3 +1,4 @@
+#include "../helper/quic-packet.h"
 #include "droplist-error-model.h"
 
 using namespace std;
@@ -18,9 +19,12 @@ DroplistErrorModel::DroplistErrorModel()
 void DroplistErrorModel::DoReset(void) { }
  
 bool DroplistErrorModel::DoCorrupt(Ptr<Packet> p) {
-    if(drops.find(++packet_num) == drops.end())
-        return false;
-    cout << "Dropping packet number " << packet_num << endl;
+    if(!IsUDPPacket(p)) return false;
+    if(drops.find(++packet_num) == drops.end()) return false;
+    
+    QuicPacket qp = QuicPacket(p);
+    cout << "Dropping packet " << packet_num << " (" << qp.GetUdpPayload().size() << " bytes) from " << qp.GetIpv4Header().GetSource() << endl;
+    qp.ReassemblePacket();
     return true;
 }
 

--- a/sim/scenarios/helper/quic-packet.cc
+++ b/sim/scenarios/helper/quic-packet.cc
@@ -6,10 +6,40 @@
 #include "ns3/packet.h"
 #include "ns3/ppp-header.h"
 #include "ns3/ipv4-header.h"
+#include "ns3/ipv6-header.h"
 #include "ns3/udp-header.h"
 
 using namespace ns3;
 using namespace std;
+
+
+bool IsUDPPacket(Ptr<Packet> p) {
+    PppHeader ppp_hdr = PppHeader();
+    p->RemoveHeader(ppp_hdr);
+    bool is_udp = false;
+    switch(ppp_hdr.GetProtocol()) {
+        case 0x21: // IPv4
+            {
+                Ipv4Header hdr = Ipv4Header();
+                p->PeekHeader(hdr);
+                is_udp = hdr.GetProtocol() == 17;
+            }
+            break;
+        case 0x57: // IPv6
+            {
+                Ipv6Header hdr = Ipv6Header();
+                p->PeekHeader(hdr);
+                is_udp = hdr.GetNextHeader() == 17;
+            }
+            break;
+        default:
+            cout << "Unknown PPP protocol: " << ppp_hdr.GetProtocol() << endl;
+            break;
+    }
+    p->AddHeader(ppp_hdr);
+    return is_udp;
+}
+
 
 QuicPacket::QuicPacket(Ptr<Packet> p) : p_(p) {
     const uint32_t p_len = p->GetSize();
@@ -17,6 +47,7 @@ QuicPacket::QuicPacket(Ptr<Packet> p) : p_(p) {
     p->CopyData(buffer, p_len);
     ppp_hdr_ = PppHeader();
     uint32_t ppp_hdr_len = p->RemoveHeader(ppp_hdr_);
+    // TODO: This currently only works for IPv4.
     ipv4_hdr_ = Ipv4Header();
     uint32_t ip_hdr_len = p->RemoveHeader(ipv4_hdr_);
     udp_hdr_ = UdpHeader();

--- a/sim/scenarios/helper/quic-packet.h
+++ b/sim/scenarios/helper/quic-packet.h
@@ -12,6 +12,8 @@
 using namespace ns3;
 using namespace std;
 
+bool IsUDPPacket(Ptr<Packet> p);
+
 class QuicPacket {
 public:
     QuicPacket(Ptr<Packet> p);

--- a/sim/scenarios/rebind/rebind-error-model.cc
+++ b/sim/scenarios/rebind/rebind-error-model.cc
@@ -46,6 +46,8 @@ void RebindErrorModel::DoRebind() {
 }
 
 bool RebindErrorModel::DoCorrupt(Ptr<Packet> p) {
+  if(!IsUDPPacket(p)) return false;
+
   QuicPacket qp = QuicPacket(p);
 
   const Ipv4Address &src_ip_in = qp.GetIpv4Header().GetSource();


### PR DESCRIPTION
cc @larseggert 

This was correct all the time, but apparently the addition of IPv6 leads to the frequent sending of ICMPv6 packets (Neighbor Soliciation messages).