### PR TITLE
Remove redundant go download

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Build endpoint
         uses: docker/build-push-action@v1
         with:
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
           path: endpoint/
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -28,6 +29,7 @@ jobs:
       - name: Build simulator
         uses: docker/build-push-action@v1
         with:
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
           path: sim/
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -10,31 +10,55 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Build endpoint
-        uses: docker/build-push-action@v1
+
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
         with:
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name == 'push' }}
-          path: endpoint/
+          image: tonistiigi/binfmt:latest
+          platforms: all
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: martenseemann/quic-network-simulator-endpoint
-          tags: latest
-          tag_with_ref: true
-          add_git_labels: true
+
+      - name: Build endpoint
+        uses: docker/build-push-action@v2
+        with:
+          context: endpoint/
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name == 'push' }}
+          tags: martenseemann/quic-network-simulator-endpoint:latest
   simulator:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Build simulator
-        uses: docker/build-push-action@v1
+
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
         with:
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name == 'push' }}
-          path: sim/
+          image: tonistiigi/binfmt:latest
+          platforms: all
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: martenseemann/quic-network-simulator
-          tags: latest
-          tag_with_ref: true
-          add_git_labels: true
+
+      - name: Build simulator
+        uses: docker/build-push-action@v2
+        with:
+          context: sim/
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name == 'push' }}
+          tags: martenseemann/quic-network-simulator:latest

--- a/sim/Dockerfile
+++ b/sim/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:20.04 AS builder
 
+ARG TARGETPLATFORM
+RUN echo "TARGETPLATFORM : $TARGETPLATFORM"
+
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y python3 build-essential cmake wget
 
@@ -13,6 +16,18 @@ WORKDIR /ns3
 RUN mkdir out/
 RUN ./waf configure --build-profile=release --out=out/
 RUN ./waf build
+
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then cd / && \
+      wget https://dl.google.com/go/go1.15.linux-amd64.tar.gz && \
+      tar xfz go1.15.linux-amd64.tar.gz && \
+      rm go1.15.linux-amd64.tar.gz; \
+    fi
+
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then cd / && \
+      wget https://dl.google.com/go/go1.15.linux-arm64.tar.gz && \
+      tar xfz go1.15.linux-arm64.tar.gz && \
+      rm go1.15.linux-arm64.tar.gz; \
+    fi
 
 RUN cd / && \
   wget https://dl.google.com/go/go1.15.linux-amd64.tar.gz && \

--- a/sim/Dockerfile
+++ b/sim/Dockerfile
@@ -29,11 +29,6 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then cd / && \
       rm go1.15.linux-arm64.tar.gz; \
     fi
 
-RUN cd / && \
-  wget https://dl.google.com/go/go1.15.linux-amd64.tar.gz && \
-  tar xfz go1.15.linux-amd64.tar.gz && \
-  rm go1.15.linux-amd64.tar.gz
-
 # make including of the QuicNetworkSimulatorHelper class possible
 COPY wscript.patch .
 RUN patch < wscript.patch


### PR DESCRIPTION
Resolves #103

For arm64 builds, Go was being downloaded and installed twice, once for Arm64 and once for Amd64. The second install was overwriting the first, and since the Arm64 Docker container cannot use the Amd64 Go, it was failing.